### PR TITLE
fix: github release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build
+        run: npm run build
+
       - name: Publish to NPM
         env:
           NODE_AUTH_TOKEN: "${{ secrets.NPM_TOKEN }}"


### PR DESCRIPTION
Release process skips build because it wasn't explicitly run and otherwise is configured only with `prerelease`, not `prepublish`.
