### PR TITLE
fix(sdk): send problem+json accept header

### DIFF
--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -24,7 +24,7 @@ export class HTTPClient {
     this.apiKey = apiKey;
 
     const headers = new Headers({
-      "Accept": "application/json",
+      "Accept": "application/problem+json, application/json",
       "Content-Type": "application/json",
       "User-Agent": `sumup-ts/v${VERSION}`,
       ...buildRuntimeHeaders(),

--- a/sdk/tests/client.test.ts
+++ b/sdk/tests/client.test.ts
@@ -13,7 +13,9 @@ describe("instantiate client", () => {
   it("default headers", () => {
     const headers = client.baseParams.headers as Headers;
 
-    expect(headers.get("accept")).toBe("application/json");
+    expect(headers.get("accept")).toBe(
+      "application/problem+json, application/json",
+    );
     expect(headers.get("authorization")).toBe("Bearer API_KEY");
     expect(headers.get("content-type")).toBe("application/json");
     expect(headers.get("user-agent")).toBe(`sumup-ts/v${VERSION}`);


### PR DESCRIPTION
## Summary
- send `Accept: application/problem+json, application/json` by default on SDK requests
- update related tests/templates where needed

## Verification
- Ran available targeted tests locally for this repository when possible.