### PR TITLE
fix(codegen): prefer problem+json for response schemas

### DIFF
--- a/codegen/src/base.ts
+++ b/codegen/src/base.ts
@@ -13,10 +13,8 @@ const getJsonMediaType = (content?: OpenAPIV3_1.ContentObject) => {
 
   const mediaTypes = Object.keys(content);
   const selectedMediaType =
-    mediaTypes.find((mediaType) => mediaType === "application/json") ||
-    mediaTypes.find(
-      (mediaType) => mediaType.endsWith("+json") || mediaType.includes("/json"),
-    );
+    mediaTypes.find((mediaType) => mediaType === "application/problem+json") ||
+    mediaTypes.find((mediaType) => mediaType === "application/json");
 
   if (!selectedMediaType) {
     return null;


### PR DESCRIPTION
## Summary
- prefer `application/problem+json` for response schema generation when present
- fall back to `application/json`
- do not generate support for multiple response media types at once

## Notes
- This branch is based on the latest `main` and includes only the second-pass response media-type selection update.