### PR TITLE
chore: simplify ants.land publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,14 +57,9 @@ jobs:
       - name: Publish to JSR
         run: npx jsr publish
 
-      - name: Install Ant
-        run: |
-          curl -fsSL https://antjs.org/install | ANT_INSTALL="${RUNNER_TEMP}/ant" bash
-          echo "${RUNNER_TEMP}/ant/bin" >> "$GITHUB_PATH"
-
       - name: Publish to ant.land
         env:
           ANT_TOKEN: "${{ secrets.ANT_TOKEN }}"
         run: |
           printf '%s\n' "//npm.ants.land/:_authToken=${ANT_TOKEN}" >> ~/.npmrc
-          ant publish --land
+          npx antland publish


### PR DESCRIPTION
Hi there!

I saw you published this package to ants.land and noticed the setup was a bit complicated. This switches it to the `antland` cli, so ant no longer needs to be installed first, reducing ci time.