### PR TITLE
feat(codegen): generate validated TypeScript code samples

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -37,5 +37,8 @@ jobs:
       - name: Build packages
         run: npm run build
 
+      - name: Test code generator and code samples
+        run: npm test
+
       - name: Lint code
         run: biome ci --diagnostic-level=error --reporter=github

--- a/.github/workflows/release-code-samples.yaml
+++ b/.github/workflows/release-code-samples.yaml
@@ -1,0 +1,131 @@
+name: Release Code Samples
+
+on:
+  release:
+    types:
+      - published
+
+concurrency:
+  group: release-code-samples-${{ github.event.release.tag_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  sync-typescript-code-samples:
+    name: Sync TypeScript code samples
+    runs-on: ubuntu-latest
+    env:
+      TARGET_REPOSITORY: sumup/sumup-developer
+      TARGET_BRANCH: automation/typescript-code-samples
+      TARGET_FILE: src/codesamples/typescript.json
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: refs/tags/${{ github.event.release.tag_name }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: codegen/package.json
+          cache: npm
+          cache-dependency-path: codegen/package-lock.json
+
+      - name: Install and build codegen
+        working-directory: codegen
+        run: |
+          npm ci
+          npm run build
+
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.SUMUP_BOT_APP_ID }}
+          private-key: ${{ secrets.SUMUP_BOT_PRIVATE_KEY }}
+          owner: sumup
+          repositories: sumup-developer
+
+      - name: Checkout target repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ env.TARGET_REPOSITORY }}
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+          path: sumup-developer
+          persist-credentials: true
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git
+        run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+
+      - name: Prepare target branch
+        working-directory: sumup-developer
+        run: |
+          git fetch origin "${{ env.TARGET_BRANCH }}:refs/remotes/origin/${{ env.TARGET_BRANCH }}" || true
+          git checkout -B "${{ env.TARGET_BRANCH }}" origin/main
+
+      - name: Generate TypeScript code samples
+        working-directory: codegen
+        run: |
+          mkdir -p "../sumup-developer/$(dirname "${{ env.TARGET_FILE }}")"
+          node dist/index.cjs samples ../openapi.json \
+            --sdk-version-file ../sdk/package.json \
+            --out "../sumup-developer/${{ env.TARGET_FILE }}"
+
+      - name: Commit generated samples
+        id: commit
+        working-directory: sumup-developer
+        run: |
+          git add "${{ env.TARGET_FILE }}"
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git commit -m "chore: update TypeScript code samples for ${{ github.event.release.tag_name }}"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Push branch
+        if: steps.commit.outputs.changed == 'true'
+        working-directory: sumup-developer
+        run: git push --force-with-lease origin "${{ env.TARGET_BRANCH }}"
+
+      - name: Create or update pull request
+        if: steps.commit.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          head_ref="sumup:${{ env.TARGET_BRANCH }}"
+          pr_url="$(gh pr list \
+            --repo "${{ env.TARGET_REPOSITORY }}" \
+            --head "$head_ref" \
+            --base main \
+            --state open \
+            --json url \
+            --jq '.[0].url')"
+
+          if [ -n "$pr_url" ]; then
+            gh pr edit "$pr_url" \
+              --repo "${{ env.TARGET_REPOSITORY }}" \
+              --title "chore: update TypeScript code samples" \
+              --body "Updates \`${{ env.TARGET_FILE }}\` from \`${{ github.repository }}\` release \`${{ github.event.release.tag_name }}\`."
+            exit 0
+          fi
+
+          gh pr create \
+            --repo "${{ env.TARGET_REPOSITORY }}" \
+            --base main \
+            --head "${{ env.TARGET_BRANCH }}" \
+            --title "chore: update TypeScript code samples" \
+            --body "Updates \`${{ env.TARGET_FILE }}\` from \`${{ github.repository }}\` release \`${{ github.event.release.tag_name }}\`."

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 .rslib/
 docs/
+/code-samples.json

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -6,11 +6,31 @@
 
 </div>
 
-## Usage
+## TypeScript SDK
+
+Generate the SDK with:
 
 ```sh
 npx @sumup/sumup-ts-codegen <schema url or file> <output dir>
 ```
+
+## TypeScript Code Samples
+
+The `samples` command generates a deterministic, versioned JSON catalog from the same OpenAPI operation model used to generate the SDK. Each entry contains a complete TypeScript program, and named OpenAPI request examples produce separate entries. The codegen tests type-check every generated program against the local SDK.
+
+Generate `code-samples.json` from the repository root with:
+
+```sh
+npm --prefix codegen run generate-codesamples
+```
+
+Pass another output path after `--` when needed:
+
+```sh
+npm --prefix codegen run generate-codesamples -- --out /tmp/typescript.json
+```
+
+Published SDK releases regenerate the catalog from the release tag and open or update a pull request for `src/codesamples/typescript.json` in `sumup/sumup-developer`; generated JSON is not committed to this repository.
 
 ## Credits
 

--- a/codegen/package.json
+++ b/codegen/package.json
@@ -45,9 +45,11 @@
   },
   "scripts": {
     "build": "tsup-node",
+    "generate-codesamples": "npm run build && node dist/index.cjs samples ../openapi.json --sdk-version-file ../sdk/package.json --out ../code-samples.json",
     "lint": "biome check",
     "lint:fix": "biome check --write",
     "prepublishOnly": "npm run build",
+    "test": "vitest run",
     "tsc": "tsc"
   },
   "dependencies": {

--- a/codegen/src/index.ts
+++ b/codegen/src/index.ts
@@ -9,7 +9,20 @@ import { generateIndex } from "./api";
 import { generateApiVersion } from "./api-version";
 import { generateCore } from "./core";
 import { generateResource } from "./resource";
+import {
+  buildSampleCatalog,
+  readSDKVersion,
+  writeSampleCatalog,
+} from "./samples";
 import { generateTypes } from "./types";
+
+async function loadSpec(specFile: string): Promise<OpenAPIV3_1.Document> {
+  const rawSpec = await SwaggerParser.parse(specFile);
+  if (!("openapi" in rawSpec) || !rawSpec.openapi.startsWith("3.0")) {
+    throw new Error("Only OpenAPI 3.0 is currently supported");
+  }
+  return rawSpec as OpenAPIV3_1.Document;
+}
 
 /**
  * Main code generation function.
@@ -26,14 +39,7 @@ async function generate(specFile: string, destDir: string) {
 `);
   }
 
-  const rawSpec = await SwaggerParser.parse(specFile);
-  if (!("openapi" in rawSpec) || !rawSpec.openapi.startsWith("3.0")) {
-    throw new Error("Only OpenAPI 3.0 is currently supported");
-  }
-
-  // we're not actually changing anything from rawSpec to spec, we've
-  // just ruled out v2 and v3.1
-  const spec = rawSpec as OpenAPIV3_1.Document;
+  const spec = await loadSpec(specFile);
 
   rmSync(resolve(destDirAbs, "resources"), { recursive: true, force: true });
   mkdirSync(resolve(destDirAbs, "resources"), { recursive: true });
@@ -55,5 +61,32 @@ program
   .action(async (specs, dir) => {
     await generate(specs, dir);
   });
+
+program
+  .command("samples")
+  .description("generate TypeScript code samples as a JSON catalog")
+  .argument("<specs>")
+  .option("-o, --out <file>", "output JSON file (defaults to stdout)")
+  .option("--sdk-version <version>", "SDK version represented by the samples")
+  .option(
+    "--sdk-version-file <file>",
+    "package.json containing the SDK version",
+    "../sdk/package.json",
+  )
+  .action(
+    async (
+      specs: string,
+      options: {
+        out?: string;
+        sdkVersion?: string;
+        sdkVersionFile: string;
+      },
+    ) => {
+      const spec = await loadSpec(specs);
+      const sdkVersion =
+        options.sdkVersion || readSDKVersion(options.sdkVersionFile);
+      writeSampleCatalog(buildSampleCatalog(spec, sdkVersion), options.out);
+    },
+  );
 
 program.parse();

--- a/codegen/src/samples.test.ts
+++ b/codegen/src/samples.test.ts
@@ -1,0 +1,109 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import SwaggerParser from "@apidevtools/swagger-parser";
+import type { OpenAPIV3_1 } from "openapi-types";
+import { describe, expect, it } from "vitest";
+import { buildSampleCatalog, readSDKVersion } from "./samples";
+
+const repositoryRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+async function catalog() {
+  const spec = (await SwaggerParser.parse(
+    resolve(repositoryRoot, "openapi.json"),
+  )) as OpenAPIV3_1.Document;
+  return buildSampleCatalog(
+    spec,
+    readSDKVersion(resolve(repositoryRoot, "sdk/package.json")),
+  );
+}
+
+describe("code sample catalog", () => {
+  it("is deterministic and follows the portal contract", async () => {
+    const first = await catalog();
+    const second = await catalog();
+
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+    expect(first).toMatchObject({
+      schemaVersion: 1,
+      language: "typescript",
+      sdk: { module: "@sumup/sdk" },
+      openAPIVersion: "1.0.0",
+    });
+    expect(first.sdk.version).toBe(
+      readSDKVersion(resolve(repositoryRoot, "sdk/package.json")),
+    );
+    expect(first.samples).toHaveLength(49);
+    expect(
+      new Set(first.samples.map((sample) => sample.operationId)),
+    ).toHaveProperty("size", 42);
+    expect(first.samples.filter((sample) => sample.example)).toHaveLength(9);
+    expect(new Set(first.samples.map((sample) => sample.id)).size).toBe(
+      first.samples.length,
+    );
+    expect(first.samples.map((sample) => sample.id)).toEqual(
+      [...first.samples.map((sample) => sample.id)].sort(),
+    );
+
+    const hosted = first.samples.find(
+      (sample) => sample.id === "CreateCheckout.HostedCheckout",
+    );
+    expect(hosted?.sample).toContain("client.checkouts.create(");
+    expect(hosted?.sample).toContain(
+      '"checkout_reference": "b50pr914-6k0e-3091-a592-890010285b3d"',
+    );
+    expect(JSON.stringify(hosted)).toContain('"sample"');
+  });
+
+  it("type-checks every program against the local SDK", async () => {
+    const generated = await catalog();
+    const output = mkdtempSync(join(tmpdir(), "sumup-ts-code-samples-"));
+
+    try {
+      generated.samples.forEach((sample, index) => {
+        writeFileSync(join(output, `sample-${index}.ts`), sample.sample);
+      });
+      writeFileSync(
+        join(output, "tsconfig.json"),
+        JSON.stringify({
+          compilerOptions: {
+            target: "ES2022",
+            module: "ESNext",
+            moduleResolution: "Bundler",
+            strict: true,
+            noEmit: true,
+            skipLibCheck: true,
+            lib: ["ES2022", "DOM", "DOM.Iterable"],
+            paths: {
+              "@sumup/sdk": [
+                relative(output, resolve(repositoryRoot, "sdk/src/index.ts")),
+              ],
+            },
+            types: ["node"],
+            typeRoots: [resolve(repositoryRoot, "codegen/node_modules/@types")],
+          },
+          include: ["*.ts"],
+        }),
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          resolve(repositoryRoot, "codegen/node_modules/typescript/bin/tsc"),
+          "-p",
+          join(output, "tsconfig.json"),
+        ],
+        { encoding: "utf8" },
+      );
+      expect(`${result.stdout}${result.stderr}`).toBe("");
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(output, { recursive: true, force: true });
+    }
+  }, 120_000);
+});

--- a/codegen/src/samples.ts
+++ b/codegen/src/samples.ts
@@ -1,0 +1,525 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { Case } from "change-case-all";
+import type { OpenAPIV3_1 } from "openapi-types";
+import { getRequestBody, iterPathConfig } from "./base";
+
+export interface SampleCatalog {
+  schemaVersion: 1;
+  language: "typescript";
+  sdk: {
+    module: "@sumup/sdk";
+    version: string;
+  };
+  openAPIVersion: string;
+  samples: CodeSample[];
+}
+
+export interface CodeSample {
+  id: string;
+  operationId: string;
+  example?: string;
+  summary?: string;
+  description?: string;
+  httpMethod: string;
+  path: string;
+  sample: string;
+}
+
+interface RequestExample {
+  name?: string;
+  summary?: string;
+  description?: string;
+  value?: unknown;
+  provided: boolean;
+}
+
+type Schema = OpenAPIV3_1.SchemaObject | OpenAPIV3_1.ReferenceObject;
+type Parameter = OpenAPIV3_1.ParameterObject;
+type Operation = OpenAPIV3_1.OperationObject & {
+  "x-codegen"?: { method_name?: string };
+};
+
+export function buildSampleCatalog(
+  spec: OpenAPIV3_1.Document,
+  sdkVersion: string,
+): SampleCatalog {
+  if (!sdkVersion.trim()) {
+    throw new Error("SDK version must not be empty");
+  }
+
+  const samples = iterPathConfig(spec.paths).flatMap(
+    ({ methodSpec, method, opId, path, pathSpec }) => {
+      const operation = methodSpec as Operation;
+      return requestExamples(spec, operation).map((example) => ({
+        id: example.name ? `${opId}.${example.name}` : opId,
+        operationId: opId,
+        ...(example.name ? { example: example.name } : {}),
+        ...optionalText("summary", example.summary || operation.summary),
+        ...optionalText(
+          "description",
+          example.description || operation.description,
+        ),
+        httpMethod: method.toUpperCase(),
+        path,
+        sample: renderProgram(spec, operation, pathSpec, example),
+      }));
+    },
+  );
+
+  samples.sort((left, right) =>
+    left.id < right.id ? -1 : left.id > right.id ? 1 : 0,
+  );
+
+  return {
+    schemaVersion: 1,
+    language: "typescript",
+    sdk: {
+      module: "@sumup/sdk",
+      version: sdkVersion.trim(),
+    },
+    openAPIVersion: spec.info.version,
+    samples,
+  };
+}
+
+export function readSDKVersion(filename: string): string {
+  const parsed = JSON.parse(readFileSync(filename, "utf8")) as {
+    version?: unknown;
+  };
+  if (typeof parsed.version !== "string" || !parsed.version.trim()) {
+    throw new Error(`SDK version file ${filename} has no version`);
+  }
+  return parsed.version.trim();
+}
+
+export function writeSampleCatalog(
+  catalog: SampleCatalog,
+  output?: string,
+): void {
+  const encoded = `${JSON.stringify(catalog, null, 2)}\n`;
+  if (!output) {
+    process.stdout.write(encoded);
+    return;
+  }
+  const filename = resolve(process.cwd(), output);
+  mkdirSync(dirname(filename), { recursive: true });
+  writeFileSync(filename, encoded);
+}
+
+function optionalText(key: "summary" | "description", value?: string) {
+  const text = value?.trim();
+  return text ? { [key]: text } : {};
+}
+
+function renderProgram(
+  spec: OpenAPIV3_1.Document,
+  operation: Operation,
+  pathItem: OpenAPIV3_1.PathItemObject,
+  example: RequestExample,
+): string {
+  const tag = operation.tags?.[0];
+  if (!tag) {
+    throw new Error(`Operation ${operation.operationId} has no tag`);
+  }
+
+  const parameters = [
+    ...(pathItem.parameters || []),
+    ...(operation.parameters || []),
+  ]
+    .map((parameter) => resolveParameter(spec, parameter))
+    .filter((parameter): parameter is Parameter => parameter !== null);
+  const pathParameters = parameters.filter(
+    (parameter) => parameter.in === "path",
+  );
+  const queryParameters = parameters.filter(
+    (parameter) => parameter.in === "query",
+  );
+
+  const args: unknown[] = pathParameters.map((parameter) =>
+    sampleParameter(spec, parameter),
+  );
+
+  const body = getRequestBody(operation.operationId || "unknown", operation);
+  if (body) {
+    args.push(
+      example.provided
+        ? coerceValue(spec, body.schema, example.value, "body")
+        : sampleSchema(spec, body.schema, "body"),
+    );
+  }
+
+  const selectedQueryParameters = queryArguments(queryParameters);
+  if (selectedQueryParameters.length > 0) {
+    args.push(
+      Object.fromEntries(
+        selectedQueryParameters.map((parameter) => [
+          parameter.name,
+          sampleParameter(spec, parameter),
+        ]),
+      ),
+    );
+  }
+
+  const methodName =
+    operation["x-codegen"]?.method_name || operation.operationId || "unknown";
+  const invocation = renderInvocation(
+    `client.${Case.camel(tag)}.${Case.camel(methodName)}`,
+    args,
+  );
+
+  return [
+    'import SumUp from "@sumup/sdk";',
+    "",
+    "async function main() {",
+    '  const client = new SumUp({ apiKey: "sup_sk_your_api_key" });',
+    "",
+    `  const result = await ${indentContinuation(invocation, 2)};`,
+    "  console.log(result);",
+    "}",
+    "",
+    "main().catch(console.error);",
+    "",
+  ].join("\n");
+}
+
+function renderInvocation(target: string, args: unknown[]): string {
+  if (args.length === 0) {
+    return `${target}()`;
+  }
+  const renderedArgs = args.map((value) => JSON.stringify(value, null, 2));
+  return `${target}(\n${renderedArgs
+    .map((value) => indent(value, 2))
+    .join(",\n")}\n)`;
+}
+
+function indent(value: string, spaces: number): string {
+  const prefix = " ".repeat(spaces);
+  return `${prefix}${value.replaceAll("\n", `\n${prefix}`)}`;
+}
+
+function indentContinuation(value: string, spaces: number): string {
+  const lines = value.split("\n");
+  return [
+    lines[0],
+    ...lines.slice(1).map((line) => `${" ".repeat(spaces)}${line}`),
+  ].join("\n");
+}
+
+function queryArguments(parameters: Parameter[]): Parameter[] {
+  const required = parameters.filter((parameter) => parameter.required);
+  if (required.length > 0) {
+    return required;
+  }
+  return parameters.length > 0 ? [parameters[0]] : [];
+}
+
+function sampleParameter(
+  spec: OpenAPIV3_1.Document,
+  parameter: Parameter,
+): unknown {
+  if (parameter.example !== undefined) {
+    return parameter.example;
+  }
+  if (parameter.examples) {
+    for (const name of Object.keys(parameter.examples).sort()) {
+      const value = resolveExample(spec, parameter.examples[name]);
+      if (value.provided) {
+        return value.value;
+      }
+    }
+  }
+  return sampleSchema(spec, parameter.schema, parameter.name);
+}
+
+function sampleSchema(
+  spec: OpenAPIV3_1.Document,
+  schema: Schema | undefined,
+  hint: string,
+  depth = 0,
+): unknown {
+  if (!schema || depth > 10) {
+    return null;
+  }
+  if ("$ref" in schema) {
+    const resolved = resolveReference<Schema>(spec, schema.$ref);
+    return resolved ? sampleSchema(spec, resolved, hint, depth + 1) : null;
+  }
+  if (schema.example !== undefined) {
+    return coerceValue(spec, schema, schema.example, hint, depth + 1);
+  }
+  if (schema.default !== undefined) {
+    return schema.default;
+  }
+  if (schema.enum && schema.enum.length > 0) {
+    return schema.enum[0];
+  }
+  if (schema.allOf) {
+    return Object.assign(
+      {},
+      ...schema.allOf.map((part) => {
+        const value = sampleSchema(spec, part, hint, depth + 1);
+        return isObject(value) ? value : {};
+      }),
+    );
+  }
+  if (schema.oneOf?.length) {
+    return sampleSchema(spec, schema.oneOf[0], hint, depth + 1);
+  }
+  if (schema.anyOf?.length) {
+    return sampleSchema(spec, schema.anyOf[0], hint, depth + 1);
+  }
+
+  const type = schema.type || (schema.properties ? "object" : undefined);
+  switch (type) {
+    case "object": {
+      const required = new Set(schema.required || []);
+      return Object.fromEntries(
+        Object.entries(schema.properties || {})
+          .filter(
+            ([name, property]) =>
+              required.has(name) || schemaHasExample(property),
+          )
+          .map(([name, property]) => [
+            name,
+            sampleSchema(spec, property, name, depth + 1),
+          ]),
+      );
+    }
+    case "array":
+      return [sampleSchema(spec, schema.items, hint, depth + 1)];
+    case "boolean":
+      return true;
+    case "integer":
+      return 1;
+    case "number":
+      return 10.1;
+    default:
+      return sampleString(schema, hint);
+  }
+}
+
+function coerceValue(
+  spec: OpenAPIV3_1.Document,
+  schema: Schema,
+  value: unknown,
+  hint: string,
+  depth = 0,
+): unknown {
+  if (depth > 10) return null;
+  if ("$ref" in schema) {
+    const resolved = resolveReference<Schema>(spec, schema.$ref);
+    return resolved
+      ? coerceValue(spec, resolved, value, hint, depth + 1)
+      : value;
+  }
+  if (schema.allOf?.length) {
+    return Object.assign(
+      {},
+      ...schema.allOf.map((part) => {
+        const coerced = coerceValue(spec, part, value, hint, depth + 1);
+        return isObject(coerced) ? coerced : {};
+      }),
+    );
+  }
+  if (schema.oneOf?.length || schema.anyOf?.length) {
+    const candidates = schema.oneOf || schema.anyOf || [];
+    const selected =
+      candidates.find((candidate) =>
+        schemaMatchesValue(spec, candidate, value),
+      ) || candidates[0];
+    return selected
+      ? coerceValue(spec, selected, value, hint, depth + 1)
+      : value;
+  }
+
+  const type = schema.type || (schema.properties ? "object" : undefined);
+  if (type === "object") {
+    const raw = isObject(value) ? value : {};
+    const properties = Object.entries(schema.properties || {});
+    const entries = properties
+      .filter(([name]) => Object.hasOwn(raw, name))
+      .map(
+        ([name, property]) =>
+          [
+            name,
+            coerceValue(spec, property, raw[name], name, depth + 1),
+          ] as const,
+      );
+    for (const required of schema.required || []) {
+      if (!entries.some(([name]) => name === required)) {
+        const property = schema.properties?.[required];
+        if (property) {
+          entries.push([
+            required,
+            sampleSchema(spec, property, required, depth + 1),
+          ]);
+        }
+      }
+    }
+    if (entries.length === 0 && properties.length > 0) {
+      const [name, property] =
+        properties.find(([, candidate]) =>
+          schemaHasNestedExample(spec, candidate),
+        ) || properties[0];
+      entries.push([name, sampleSchema(spec, property, name, depth + 1)]);
+    }
+    return Object.fromEntries(entries);
+  }
+  if (type === "array") {
+    const items = "items" in schema ? schema.items : undefined;
+    const values = Array.isArray(value) ? value : [];
+    return values.length > 0
+      ? values.map((item) =>
+          items ? coerceValue(spec, items, item, hint, depth + 1) : item,
+        )
+      : [sampleSchema(spec, items, hint, depth + 1)];
+  }
+  if (type === "boolean") return typeof value === "boolean" ? value : true;
+  if (type === "integer" || type === "number") {
+    return typeof value === "number" ? value : type === "integer" ? 1 : 10.1;
+  }
+  return typeof value === "string" ? value : sampleString(schema, hint);
+}
+
+function schemaMatchesValue(
+  spec: OpenAPIV3_1.Document,
+  schema: Schema,
+  value: unknown,
+): boolean {
+  const resolved =
+    "$ref" in schema ? resolveReference<Schema>(spec, schema.$ref) : schema;
+  if (!resolved || "$ref" in resolved) return false;
+  if (resolved.properties && isObject(value)) {
+    return Object.keys(resolved.properties).some((name) =>
+      Object.hasOwn(value, name),
+    );
+  }
+  return true;
+}
+
+function schemaHasNestedExample(
+  spec: OpenAPIV3_1.Document,
+  schema: Schema,
+  depth = 0,
+): boolean {
+  if (depth > 8) return false;
+  if ("$ref" in schema) {
+    const resolved = resolveReference<Schema>(spec, schema.$ref);
+    return !!resolved && schemaHasNestedExample(spec, resolved, depth + 1);
+  }
+  return (
+    schemaHasExample(schema) ||
+    Object.values(schema.properties || {}).some((property) =>
+      schemaHasNestedExample(spec, property, depth + 1),
+    )
+  );
+}
+
+function schemaHasExample(schema: Schema): boolean {
+  return "$ref" in schema
+    ? false
+    : schema.example !== undefined ||
+        schema.default !== undefined ||
+        !!schema.enum?.length;
+}
+
+function sampleString(schema: OpenAPIV3_1.SchemaObject, hint: string): string {
+  if (schema.format === "date") return "2025-01-01";
+  if (schema.format === "date-time") return "2025-01-01T12:00:00Z";
+  if (schema.format === "uuid") return "00000000-0000-0000-0000-000000000000";
+  if (schema.format === "uri" || schema.format === "url") {
+    return "https://example.com";
+  }
+  if (hint.includes("merchant_code")) return "M123456789";
+  if (hint.includes("checkout")) return "checkout-id";
+  if (hint.includes("email")) return "user@example.com";
+  return "example";
+}
+
+function requestExamples(
+  spec: OpenAPIV3_1.Document,
+  operation: Operation,
+): RequestExample[] {
+  const requestBody = resolveRequestBody(spec, operation.requestBody);
+  const media = requestBody?.content?.["application/json"];
+  if (!media) {
+    return [{ provided: false }];
+  }
+  if (media.examples && Object.keys(media.examples).length > 0) {
+    return Object.keys(media.examples)
+      .sort()
+      .map((name) => {
+        const example = resolveExample(spec, media.examples?.[name]);
+        return { name, ...example };
+      });
+  }
+  if (media.example !== undefined) {
+    return [{ value: media.example, provided: true }];
+  }
+  if (media.schema) {
+    return [
+      {
+        value: sampleSchema(spec, media.schema, "body"),
+        provided: true,
+      },
+    ];
+  }
+  return [{ provided: false }];
+}
+
+function resolveExample(
+  spec: OpenAPIV3_1.Document,
+  example: OpenAPIV3_1.ReferenceObject | OpenAPIV3_1.ExampleObject | undefined,
+): Omit<RequestExample, "name"> {
+  if (!example) {
+    return { provided: false };
+  }
+  const resolved =
+    "$ref" in example
+      ? resolveReference<OpenAPIV3_1.ExampleObject>(spec, example.$ref)
+      : example;
+  if (!resolved || resolved.value === undefined) {
+    return { provided: false };
+  }
+  return {
+    value: resolved.value,
+    provided: true,
+    ...optionalText("summary", resolved.summary),
+    ...optionalText("description", resolved.description),
+  };
+}
+
+function resolveRequestBody(
+  spec: OpenAPIV3_1.Document,
+  body: OpenAPIV3_1.ReferenceObject | OpenAPIV3_1.RequestBodyObject | undefined,
+): OpenAPIV3_1.RequestBodyObject | null {
+  if (!body) return null;
+  if (!("$ref" in body)) return body;
+  return resolveReference<OpenAPIV3_1.RequestBodyObject>(spec, body.$ref);
+}
+
+function resolveParameter(
+  spec: OpenAPIV3_1.Document,
+  parameter: OpenAPIV3_1.ReferenceObject | Parameter,
+): Parameter | null {
+  if (!("$ref" in parameter)) return parameter;
+  return resolveReference<Parameter>(spec, parameter.$ref);
+}
+
+function resolveReference<T>(
+  spec: OpenAPIV3_1.Document,
+  reference: string,
+): T | null {
+  if (!reference.startsWith("#/")) return null;
+  let value: unknown = spec;
+  for (const part of reference.slice(2).split("/")) {
+    if (!isObject(value)) return null;
+    value = value[part.replaceAll("~1", "/").replaceAll("~0", "~")];
+  }
+  return (value as T | undefined) || null;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## What

- generate a deterministic, versioned JSON catalog containing 49 complete TypeScript programs for the 42 current OpenAPI operations, including 9 separately addressable named request examples
- expose generation through the codegen package's native npm command and type-check every generated program against the local SDK
- sync the release-tag catalog into `sumup-developer/src/codesamples/typescript.json` through a draft portal PR

## Why

The developer portal needs accurate SDK samples that stay aligned with the OpenAPI model and generated client rather than a separately maintained set of snippets. A checked-in JSON sync contract keeps the portal integration static and avoids shipping codegen or WASM to the browser.

## Checks

- `npm --prefix codegen run build`
- `npm --prefix codegen run lint`
- `npm --prefix codegen test`
- `npm --prefix codegen run generate-codesamples -- --out /tmp/sumup-ts-script-catalog.json`
- generated sample programs type-checked against `sdk/src`
- `npm --prefix sdk run generate` (no generated drift)
- `npm --prefix sdk run build`
- `npm --prefix sdk test`
- `actionlint .github/workflows/codegen.yaml .github/workflows/release-code-samples.yaml`

