### PR TITLE
fix(codegen)!: normalize repeated query parameter names

### DIFF
--- a/codegen/src/base.test.ts
+++ b/codegen/src/base.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "vitest";
+import { queryParameterName } from "./base";
+
+test("removes a bracket suffix from repeated query parameter names", () => {
+  expect(
+    queryParameterName({
+      in: "query",
+      name: "statuses[]",
+      schema: { type: "array", items: { type: "string" } },
+    }),
+  ).toBe("statuses");
+});
+
+test("preserves bracket suffixes on non-array query parameter names", () => {
+  expect(
+    queryParameterName({
+      in: "query",
+      name: "filter[]",
+      schema: { type: "string" },
+    }),
+  ).toBe("filter[]");
+});
+
+test("preserves array query parameter names without a bracket suffix", () => {
+  expect(
+    queryParameterName({
+      in: "query",
+      name: "include",
+      schema: { type: "array", items: { type: "string" } },
+    }),
+  ).toBe("include");
+});

--- a/codegen/src/base.ts
+++ b/codegen/src/base.ts
@@ -134,6 +134,22 @@ export function getResponse(
   return inlineTypeName;
 }
 
+/**
+ * Returns the ergonomic SDK name for an OpenAPI query parameter.
+ *
+ * Some APIs use bracket-suffixed names to indicate repeated query parameters.
+ * The brackets are a wire-format concern, so array parameters omit them from
+ * the generated SDK surface.
+ */
+export function queryParameterName(param: OpenAPIV3_1.ParameterObject): string {
+  const schema = param.schema;
+  const isArray = schema && !("$ref" in schema) && schema.type === "array";
+
+  return isArray && param.name.endsWith("[]")
+    ? param.name.slice(0, -2)
+    : param.name;
+}
+
 type PathConfig = ReturnType<typeof iterPathConfig>[number];
 
 /**

--- a/codegen/src/core.ts
+++ b/codegen/src/core.ts
@@ -27,6 +27,19 @@ export class APIResource {
   constructor(client: ${apiName}) {
     this._client = client;
   }
+
+  protected _transformQueryParams(
+    query: QueryParams | undefined,
+    names: Record<string, string>,
+  ): QueryParams | undefined {
+    if (!query) {
+      return query;
+    }
+
+    return Object.fromEntries(
+      Object.entries(query).map(([name, value]) => [names[name] ?? name, value]),
+    );
+  }
 }
 
 // has to be any. the particular query params types don't like unknown

--- a/codegen/src/resource.ts
+++ b/codegen/src/resource.ts
@@ -7,6 +7,7 @@ import {
   getSortedSchemas,
   iterParams,
   iterPathConfig,
+  queryParameterName,
   responseSchema,
 } from "./base";
 import { fileWriter } from "./io";
@@ -205,7 +206,7 @@ export async function generateResource(
           }
         }
 
-        writer.w(`  '${param.name}'`);
+        writer.w(`  '${queryParameterName(param)}'`);
         if (!param.required) writer.w0("?");
         writer.w0(": ");
         schemaToTypes(param.schema, writer);
@@ -289,6 +290,9 @@ export class ${resourceClassName} extends APIResource {`);
     const queryParams = params.filter(
       (p) => "in" in p && p.in === "query",
     ) as OpenAPIV3_1.ParameterObject[];
+    const renamedQueryParams = queryParams
+      .map((param) => [queryParameterName(param), param.name] as const)
+      .filter(([name, wireName]) => name !== wireName);
 
     const successResponses = Object.entries(methodSpec.responses)
       .filter(([code]) => code.startsWith("2"))
@@ -333,7 +337,15 @@ export class ${resourceClassName} extends APIResource {`);
       writer.w("  body,");
     }
     if (queryParams.length > 0) {
-      writer.w("  query,");
+      if (renamedQueryParams.length > 0) {
+        writer.w("  query: this._transformQueryParams(query, {");
+        for (const [name, wireName] of renamedQueryParams) {
+          writer.w(`    '${name}': '${wireName}',`);
+        }
+        writer.w("  }),");
+      } else {
+        writer.w("  query,");
+      }
     }
     writer.w(`  ...options,
          })
@@ -369,7 +381,15 @@ export class ${resourceClassName} extends APIResource {`);
       writer.w("  body,");
     }
     if (queryParams.length > 0) {
-      writer.w("  query,");
+      if (renamedQueryParams.length > 0) {
+        writer.w("  query: this._transformQueryParams(query, {");
+        for (const [name, wireName] of renamedQueryParams) {
+          writer.w(`    '${name}': '${wireName}',`);
+        }
+        writer.w("  }),");
+      } else {
+        writer.w("  query,");
+      }
     }
     writer.w(`  ...options,
          })

--- a/codegen/src/samples.ts
+++ b/codegen/src/samples.ts
@@ -2,7 +2,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { Case } from "change-case-all";
 import type { OpenAPIV3_1 } from "openapi-types";
-import { getRequestBody, iterPathConfig } from "./base";
+import { getRequestBody, iterPathConfig, queryParameterName } from "./base";
 
 export interface SampleCatalog {
   schemaVersion: 1;
@@ -154,7 +154,7 @@ function renderProgram(
     args.push(
       Object.fromEntries(
         selectedQueryParameters.map((parameter) => [
-          parameter.name,
+          queryParameterName(parameter),
           sampleParameter(spec, parameter),
         ]),
       ),

--- a/sdk/src/core.ts
+++ b/sdk/src/core.ts
@@ -8,6 +8,22 @@ export class APIResource {
   constructor(client: SumUp) {
     this._client = client;
   }
+
+  protected _transformQueryParams(
+    query: QueryParams | undefined,
+    names: Record<string, string>,
+  ): QueryParams | undefined {
+    if (!query) {
+      return query;
+    }
+
+    return Object.fromEntries(
+      Object.entries(query).map(([name, value]) => [
+        names[name] ?? name,
+        value,
+      ]),
+    );
+  }
 }
 
 // has to be any. the particular query params types don't like unknown

--- a/sdk/src/resources/transactions/index.ts
+++ b/sdk/src/resources/transactions/index.ts
@@ -32,17 +32,17 @@ export type ListTransactionsV2_1QueryParams = {
   transaction_code?: string;
   order?: "ascending" | "descending";
   limit?: number;
-  "users[]"?: string[];
-  "statuses[]"?: (
+  users?: string[];
+  statuses?: (
     | "SUCCESSFUL"
     | "CANCELLED"
     | "FAILED"
     | "REFUNDED"
     | "CHARGE_BACK"
   )[];
-  "payment_types[]"?: PaymentType[];
-  "entry_modes[]"?: EntryMode[];
-  "types[]"?: ("PAYMENT" | "REFUND" | "CHARGE_BACK")[];
+  payment_types?: PaymentType[];
+  entry_modes?: EntryMode[];
+  types?: ("PAYMENT" | "REFUND" | "CHARGE_BACK")[];
   changes_since?: string;
   newest_time?: string;
   newest_ref?: string;
@@ -154,7 +154,13 @@ export class Transactions extends APIResource {
   ): Promise<ListTransactionsV2_1Response> {
     return this._client.get<ListTransactionsV2_1Response>({
       path: `/v2.1/merchants/${merchantCode}/transactions/history`,
-      query,
+      query: this._transformQueryParams(query, {
+        users: "users[]",
+        statuses: "statuses[]",
+        payment_types: "payment_types[]",
+        entry_modes: "entry_modes[]",
+        types: "types[]",
+      }),
       ...options,
     });
   }
@@ -166,7 +172,13 @@ export class Transactions extends APIResource {
   ): Promise<WithResponse<ListTransactionsV2_1Response>> {
     return this._client.getWithResponse<ListTransactionsV2_1Response>({
       path: `/v2.1/merchants/${merchantCode}/transactions/history`,
-      query,
+      query: this._transformQueryParams(query, {
+        users: "users[]",
+        statuses: "statuses[]",
+        payment_types: "payment_types[]",
+        entry_modes: "entry_modes[]",
+        types: "types[]",
+      }),
       ...options,
     });
   }

--- a/sdk/tests/client.test.ts
+++ b/sdk/tests/client.test.ts
@@ -163,6 +163,28 @@ describe("request options", () => {
 });
 
 describe("generated signatures", () => {
+  it("maps ergonomic repeated query parameter names to their wire names", () => {
+    const client = new SumUp();
+    const getSpy = vi
+      .spyOn(client, "get")
+      .mockReturnValue({} as ReturnType<typeof client.get>);
+
+    client.transactions.list("MC123", {
+      limit: 10,
+      statuses: ["SUCCESSFUL", "REFUNDED"],
+      users: ["user-1", "user-2"],
+    });
+
+    expect(getSpy).toHaveBeenCalledWith({
+      path: "/v2.1/merchants/MC123/transactions/history",
+      query: {
+        limit: 10,
+        "statuses[]": ["SUCCESSFUL", "REFUNDED"],
+        "users[]": ["user-1", "user-2"],
+      },
+    });
+  });
+
   it("keeps request options in the final argument position", () => {
     const client = new SumUp();
     const getSpy = vi


### PR DESCRIPTION
Strip the trailing `[]` from array query parameters in the generated SDK types and code samples. Map them back to their original wire names before sending API requests.

Related: https://github.com/sumup/sumup-mcp/issues/76