### PR TITLE
fix(sdk): resolve declaration imports in NodeNext

### DIFF
--- a/sdk/rslib.config.ts
+++ b/sdk/rslib.config.ts
@@ -6,7 +6,10 @@ export default defineConfig({
     {
       format: "esm",
       syntax: "es2022",
-      dts: true,
+      dts: {
+        autoExtension: true,
+      },
+      redirect: { dts: { path: true, extension: true } },
       output: {
         target: "web",
       },
@@ -17,6 +20,7 @@ export default defineConfig({
       dts: {
         autoExtension: true,
       },
+      redirect: { dts: { path: true, extension: true } },
     },
   ],
   output: {


### PR DESCRIPTION
Extensionless declaration imports break SDK types in NodeNext consumers. Rewrite declaration paths and extensions for ESM and CommonJS outputs.